### PR TITLE
Implement userCan hook.

### DIFF
--- a/MediaWiki/PdfBook/PdfBook.hooks.php
+++ b/MediaWiki/PdfBook/PdfBook.hooks.php
@@ -88,6 +88,7 @@ class PdfBookHooks {
 				$wgUploadPath  = $wgServer.$wgUploadPath;
 				$wgScript      = $wgServer.$wgScript;
 				foreach( $articles as $title ) {
+					if (!$title->userCan( 'read' )) continue;
 					$ttext = $title->getPrefixedText();
 					if( !in_array( $ttext, $exclude ) ) {
 						$article = new Article( $title );


### PR DESCRIPTION
Skips exporting articles which the user is not permitted to read.

This may not be a complete solution, caching and broken links to this page within the PDF come to mind. But this hook is a starting point to allow integration with most access control extensions.

Such as https://www.mediawiki.org/wiki/Extension:AccessControl